### PR TITLE
Search for libcuda.so.1 as well, not all Linux distributions have libcuda.so

### DIFF
--- a/src/cuew.c
+++ b/src/cuew.c
@@ -338,7 +338,7 @@ static int cuewCudaInit(void) {
   /* Default installation path. */
   const char *cuda_paths[] = {"/usr/local/cuda/lib/libcuda.dylib", NULL};
 #else
-  const char *cuda_paths[] = {"libcuda.so", NULL};
+  const char *cuda_paths[] = {"libcuda.so", "libcuda.so.1", NULL};
 #endif
   static int initialized = 0;
   static int result = 0;


### PR DESCRIPTION
See https://github.com/flathub/org.blender.Blender/issues/8

We used to have this in Blender, but it seems to have gotten removed when switching to cuew, which I guess was not intentional?
https://developer.blender.org/rB8cd88e3bd0